### PR TITLE
fix phpunit configuration to work with phpunit 6 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="tests/bootstrap.php"
+         bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
@@ -11,9 +11,11 @@
          syntaxCheck="false"
          verbose="true"
 >
+
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
+
 </phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once dirname(__FILE__).'/../src/Seasons.php';

--- a/tests/seasons.php
+++ b/tests/seasons.php
@@ -1,6 +1,8 @@
 <?php
 
-class seasons extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Seasons extends TestCase
 {
     protected $season;
 


### PR DESCRIPTION
From phpunit 6 the namespace is PHPUnit\Framework\TestCase and this cause tests failure. There was also a typo in class name. Finally, this PR fix the bootstrap file to the vendor/autoload.php.