### PR TITLE
improve season provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Jaybizzle\\": "src/"
+            "": "src/"
         }
     },
     "config": {

--- a/src/JayBizzle/Seasons.php
+++ b/src/JayBizzle/Seasons.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Jaybizzle;
+namespace JayBizzle;
 
 class Seasons
 {
@@ -64,7 +64,28 @@ class Seasons
      */
     public function get($date = null)
     {
-        return $this->seasons[(int) (($this->getMonth($date) % 12) / 3)];
+        return $this->getSeasonFromDateTime(
+            new \DateTime($date)
+        );
+    }
+
+    public function getSeasonFromDateTime(\DateTime $dateTime)
+    {
+        $dayOfTheYear = $dateTime->format('z');
+
+        if (in_array($dayOfTheYear, range(79, 171))) {
+            return $this->seasons[1];
+        }
+
+        if (in_array($dayOfTheYear, range(172, 264))) {
+            return $this->seasons[2];
+        }
+
+        if (in_array($dayOfTheYear, range(265, 354))) {
+            return $this->seasons[3];
+        }
+
+        return $this->seasons[0];
     }
 
     /**

--- a/tests/SeasonsTest.php
+++ b/tests/SeasonsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use JayBizzle\Seasons;
 
 class SeasonsTest extends TestCase
 {
@@ -8,7 +9,27 @@ class SeasonsTest extends TestCase
 
     public function setUp()
     {
-        $this->season = new Jaybizzle\Seasons();
+        $this->season = new Seasons();
+    }
+
+    /**
+     * @dataProvider fussyDateStrings
+     */
+    public function testMustProvideSeasonByDateTime(
+        $dateTimeValue,
+        $expected
+    ) {
+        $dateTimeObject = new \DateTime($dateTimeValue);
+        $result = $this->season->getSeasonFromDateTime($dateTimeObject);
+        $this->assertequals($expected, $result);
+    }
+
+    public function fussyDateStrings()
+    {
+        return array(
+            array('20st March', Seasons::SEASON_WINTER),
+            array('21st March', Seasons::SEASON_SPRING),
+        );
     }
 
     /**
@@ -23,7 +44,10 @@ class SeasonsTest extends TestCase
     public function dateStrings()
     {
         return array(
-            array('June', 'Summer'),
+            array('20st March', Seasons::SEASON_WINTER),
+            array('21st March', Seasons::SEASON_SPRING),
+            array('25st July', Seasons::SEASON_SUMMER),
+            array('June', 'Spring'), // june starts in spring and finish in summer
             array('1st October 2016', 'Autumn'),
             array('31st December', 'Winter'),
         );
@@ -59,7 +83,7 @@ class SeasonsTest extends TestCase
 
     public function testProvideSeasonsReange()
     {
-        $winterRange = $this->season->monthRange(Jaybizzle\Seasons::SEASON_WINTER);
+        $winterRange = $this->season->monthRange(Seasons::SEASON_WINTER);
         $this->assertEquals(
             array(12, 1, 2),
             $winterRange
@@ -68,11 +92,11 @@ class SeasonsTest extends TestCase
 
     public function testProvideSeasonsReangeInSouthernRegionOfTheWorld()
     {
-        $winter = $this->season->monthRange(Jaybizzle\Seasons::SEASON_WINTER);
+        $winter = $this->season->monthRange(Seasons::SEASON_WINTER);
 
         $season = $this->season->southern();
 
-        $southernSpring = $season->monthRange(Jaybizzle\Seasons::SEASON_SUMMER);
+        $southernSpring = $season->monthRange(Seasons::SEASON_SUMMER);
 
         $this->assertEquals(
             $winter,


### PR DESCRIPTION
This should fix #14 . With this PR new method were added. It force the use of a DateTime object. It is called:

    getSeasonFromDateTime

and replace old code.